### PR TITLE
[slack.emoji-vote] switch to blocks, add support for eligible_voters parameters

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -392,7 +392,7 @@ In order to use the Metagov Slack plugin, the Metagov server administrator
 needs to create a new Slack App and store its credentials on the Metagov server:
 
 1. Go to https://api.slack.com/apps
-2. Click “Create New App” and select "From and app manifest"
+2. Click “Create New App” and select "From an app manifest"
 3. Paste in the `manifest.yaml file <https://github.com/metagov/metagov-prototype/blob/master/metagov/metagov/plugins/slack/manifest.yaml>`_. Replace ``$METAGOV_SERVER`` with the URL for your Metagov server under ``redirect_urls`` and ``request_url``. Optional: adjust scopes, events, and bot name as desired.
 4. Click “Manage Distribution”->”Activate Public Distribution.” This step is necessary if you want your app to be installable to multiple Slack workspaces.
 5. On the Metagov server, create the Slack ``.env`` file and fill in the App ID, Client ID, Client Secret, and Signing Secret.

--- a/metagov/metagov/plugins/github/test_github.py
+++ b/metagov/metagov/plugins/github/test_github.py
@@ -64,7 +64,7 @@ class UnitTests(TestCase):
         self.assertListEqual(no_votes, ["foo"])
 
     def test_boolean_reaction_dict_empty(self):
-        """Test that the reactions_to_dict function counts votes correctly"""
+        """Test that the reactions_to_user_lists function counts votes correctly"""
         reactions = [
             {
                 "user": {"login": "foo", "type": "User"},

--- a/metagov/metagov/plugins/slack/manifest.yaml
+++ b/metagov/metagov/plugins/slack/manifest.yaml
@@ -90,5 +90,9 @@ settings:
       - team_domain_change
       - team_rename
       - user_change
+  interactivity:
+    is_enabled: true
+    # Replace me!
+    request_url: $METAGOV_SERVER/api/hooks/slack
   org_deploy_enabled: false
   socket_mode_enabled: false

--- a/metagov/metagov/plugins/slack/tests/test_slack.py
+++ b/metagov/metagov/plugins/slack/tests/test_slack.py
@@ -1,6 +1,6 @@
 import requests_mock
 from django.test import TestCase
-from metagov.plugins.slack.models import Slack, SlackEmojiVote, reactions_to_dict
+from metagov.plugins.slack.models import Slack
 from metagov.tests.plugin_test_utils import PluginTestCase
 
 
@@ -14,46 +14,3 @@ class ApiTests(PluginTestCase):
         """Plugin is properly initialized"""
         plugin = Slack.objects.first()
         self.assertIsNotNone(plugin)
-
-
-class UnitTests(TestCase):
-    def test_boolean_reaction_dict(self):
-        """Test that the reactions_to_dict function collapses thumb votes correctly"""
-        reactions = [
-            {"name": "-1", "users": ["B1", "U1", "U2"], "count": 2},
-            {"name": "-1::skin-tone-2", "users": ["B1", "U2"], "count": 1},
-            {"name": "-1::skin-tone-6", "users": ["B1", "U3"], "count": 1},
-            {"name": "+1", "users": ["B1", "U4"], "count": 1},
-            {"name": "blue_heart", "users": ["U4"], "count": 1},
-            {"name": "yellow_heart", "users": ["U4"], "count": 1},
-        ]
-        emoji_to_option = {"+1": "yes", "-1": "no"}
-        votes = reactions_to_dict(
-            reactions,
-            emoji_to_option,
-            excluded_users=["B1"],
-        )
-        self.assertDictEqual(
-            votes,
-            {
-                "no": {"users": ["U1", "U2", "U3"], "count": 3},
-                "yes": {"users": ["U4"], "count": 1},
-            },
-        )
-
-    def test_choice_reaction_dict(self):
-        """Test that the reactions_to_dict function collapses votes correctly"""
-        reactions = [
-            {"name": "blue_heart", "users": ["U1", "U2"], "count": 2},
-            {"name": "yellow_heart", "users": ["U1", "U3"], "count": 2},
-        ]
-        emoji_to_option = {"blue_heart": "opt_1", "yellow_heart": "opt_2", "purple_heart": "opt_3"}
-        votes = reactions_to_dict(reactions, emoji_to_option)
-        self.assertDictEqual(
-            votes,
-            {
-                "opt_1": {"users": ["U1", "U2"], "count": 2},
-                "opt_2": {"users": ["U1", "U3"], "count": 2},
-                "opt_3": {"users": [], "count": 0},
-            },
-        )


### PR DESCRIPTION
* Allow restricting voters using `eligible_voters` and `ineligible_voters` param. Ineligible voters are unable to cast votes. When they try to, they'll get an ephemeral message saying that they can't vote. That message is customizable using the `ineligible_voter_message` param. Closes https://github.com/metagov/metagov-prototype/issues/122
* Switch emoji-vote process to use the [Slack block kit](https://api.slack.com/block-kit). This change is necessary in order to support most of the enhancements laid out in https://github.com/metagov/metagov-prototype/issues/85. Specifically because we cannot use the bot token to remove voters reactions; reactions can only be removed by the users who added them. Blocks will also let us do things like: choose to make votes anonymous, reveal votes only when the vote has closed, allow minimum/maximum number of votes people can cast, etc.


choice vote:
<img width="680" alt="Screen Shot 2021-10-20 at 14 17 58" src="https://user-images.githubusercontent.com/5333982/138149086-6aae04fa-d6b4-4892-9457-39cdd81646d8.png">


boolean vote:
<img width="672" alt="Screen Shot 2021-10-20 at 14 18 14" src="https://user-images.githubusercontent.com/5333982/138149134-2ff185b7-ac1d-4b7e-8481-cae0d185be51.png">

