### PR TITLE
Call plugin initialize after it is saved

### DIFF
--- a/metagov/metagov/core/models.py
+++ b/metagov/metagov/core/models.py
@@ -181,11 +181,10 @@ class Plugin(models.Model):
     def save(self, *args, **kwargs):
         if not self.pk:
             self.state = DataStore.objects.create()
-            self.initialize()
         super(Plugin, self).save(*args, **kwargs)
 
     def initialize(self):
-        """Initialize the plugin. Invoked once, when the plugin instance is created."""
+        """Initialize the plugin. Invoked once, directly after the plugin instance is created."""
         pass
 
     def start_process(self, process_name, callback_url=None, **kwargs):

--- a/metagov/metagov/core/utils.py
+++ b/metagov/metagov/core/utils.py
@@ -107,6 +107,7 @@ def create_or_update_plugin(plugin_name, plugin_config, community):
             name=plugin_name, community=community, config=plugin_config, community_platform_id=community_platform_id
         )
         logger.info(f"Created plugin '{inst}'")
+        inst.initialize()
         return (inst, True)
     else:
         if plugin.config != plugin_config:
@@ -119,6 +120,7 @@ def create_or_update_plugin(plugin_name, plugin_config, community):
                 config=plugin_config,
                 community_platform_id=community_platform_id,
             )
+            inst.initialize()
             return (inst, True)
 
         logger.info(f"Not updating '{plugin}', no change in config.")

--- a/metagov/metagov/plugins/loomio/models.py
+++ b/metagov/metagov/plugins/loomio/models.py
@@ -39,6 +39,7 @@ class Loomio(Plugin):
 
         # Set the community_platform_id to the main group handle
         self.community_platform_id = api_key_group_map[self.config["api_key"]]["handle"]
+        self.save()
 
     def _get_api_key(self, key_or_handle=None):
         """Get the API key for a specific Loomio group. Raises exception if not found."""

--- a/metagov/metagov/plugins/loomio/models.py
+++ b/metagov/metagov/plugins/loomio/models.py
@@ -38,9 +38,7 @@ class Loomio(Plugin):
         self.state.set("api_key_group_map", api_key_group_map)
 
         # Set the community_platform_id to the main group handle
-        parent_group_handle = api_key_group_map[self.config["api_key"]]["handle"]
-        self.community_platform_id = parent_group_handle
-        self.save()
+        self.community_platform_id = api_key_group_map[self.config["api_key"]]["handle"]
 
     def _get_api_key(self, key_or_handle=None):
         """Get the API key for a specific Loomio group. Raises exception if not found."""


### PR DESCRIPTION
Initialize plugins after creating, instead of during the save. This fixes a bug where Loomio would get in an infinite loop because it was calling save() from init.