### PR TITLE
Missing scope in Slack manifest.yaml

### DIFF
--- a/metagov/metagov/plugins/slack/manifest.yaml
+++ b/metagov/metagov/plugins/slack/manifest.yaml
@@ -21,6 +21,7 @@ oauth_config:
       - reactions:read
       - chat:write
     bot:
+      - app_mentions:read
       - calls:read
       - calls:write
       - channels:history


### PR DESCRIPTION
When trying to set up a new Slack app, I had to add this scope.