### PR TITLE
Send data to loomio as json

### DIFF
--- a/metagov/metagov/plugins/loomio/models.py
+++ b/metagov/metagov/plugins/loomio/models.py
@@ -118,7 +118,7 @@ class LoomioPoll(GovernanceProcess):
 
         payload["options[]"] = parameters.options
         payload["api_key"] = api_key
-        resp = requests.post(url, payload)
+        resp = requests.post(url, json=payload)
         if not resp.ok:
             logger.error(f"Error: {resp.status_code} {resp.text}")
             raise PluginErrorInternal(resp.text)


### PR DESCRIPTION
This should fix the distressingly long-standing bug with the Loomio integration where Loomio was failing to notify people of new polls. The issue, we believe, was that we were sending data as a form rather than a json and that Loomio was silently redirecting to the old version of their API where the key for recipients was "recipient_emails[]" and "recipient_user_ids[]" rather than "recipient_emails" and "recipient_user_ids" as their current docs state. This caused only the last item in the array supplied to be used. Hopefully by specifying that the payload should be read as json we'll get directed to the current API. If not, we can go in and manually add the [] to our parameter names.