### PR TITLE
Use OAuth for Open Collective plugin

### DIFF
--- a/metagov/metagov/core/handlers.py
+++ b/metagov/metagov/core/handlers.py
@@ -159,7 +159,7 @@ class MetagovRequestHandler:
 
         redirect_uri, type, community_slug, metagov_id = self.check_request_values(request, redirect_uri, type, community_slug, metagov_id)
 
-        logger.debug(f"Handling {type} authorization request for {plugin_name}' to community '{community_slug}'")
+        logger.debug(f"Handling {type} authorization request for '{plugin_name}' to community '{community_slug}'")
 
         # Get plugin handler
         if not plugin_registry.get(plugin_name):

--- a/metagov/metagov/plugins/opencollective/handlers.py
+++ b/metagov/metagov/plugins/opencollective/handlers.py
@@ -7,7 +7,7 @@ from django.http.response import HttpResponseBadRequest, HttpResponseRedirect
 from metagov.core.errors import PluginAuthError
 from metagov.core.plugin_manager import AuthorizationType
 from metagov.core.models import ProcessStatus
-from metagov.plugins.opencollective.models import OpenCollective, OPEN_COLLECTIVE_GRAPHQL
+from metagov.plugins.opencollective.models import OpenCollective, OPEN_COLLECTIVE_URL, OPEN_COLLECTIVE_GRAPHQL
 from requests.models import PreparedRequest
 from metagov.core.handlers import PluginRequestHandler
 
@@ -31,7 +31,7 @@ class OpenCollectiveRequestHandler(PluginRequestHandler):
         # if type == AuthorizationType.APP_INSTALL:    
         # elif type == AuthorizationType.USER_LOGIN:
 
-        return f"https://opencollective.com/oauth/authorizeauthorize?response_type=code&client_id={OC_CLIENT_ID}&scope={admin_scopes.join(',')}"
+        return f"{OPEN_COLLECTIVE_URL}/oauth/authorize?response_type=code&client_id={OC_CLIENT_ID}&scope={','.join(admin_scopes)}"
 
     def handle_oauth_callback(
         self,
@@ -125,7 +125,7 @@ def _exchange_code(code):
         "code": code,
         "redirect_uri": f"{settings.SERVER_URL}/auth/opencollective/callback",
     }
-    resp = requests.post("https://opencollective.com/oauth/token", data=data)
+    resp = requests.post(f"{OPEN_COLLECTIVE_URL}/oauth/token", data=data)
     if not resp.ok:
         logger.error(f"OC auth failed: {resp.status_code} {resp.reason}")
         raise PluginAuthError

--- a/metagov/metagov/plugins/opencollective/handlers.py
+++ b/metagov/metagov/plugins/opencollective/handlers.py
@@ -106,6 +106,7 @@ class OpenCollectiveRequestHandler(PluginRequestHandler):
                 name="opencollective", community=community, config=plugin_config, community_platform_id=collective
             )
             logger.debug(f"Created OC plugin: {plugin}")
+            plugin.initialize()
 
             params = {
                 # Metagov community that has the OC plugin enabled

--- a/metagov/metagov/plugins/opencollective/handlers.py
+++ b/metagov/metagov/plugins/opencollective/handlers.py
@@ -1,0 +1,141 @@
+import json
+import logging
+import requests
+from django.conf import settings
+
+from django.http.response import HttpResponseBadRequest, HttpResponseRedirect
+from metagov.core.errors import PluginAuthError
+from metagov.core.plugin_manager import AuthorizationType
+from metagov.core.models import ProcessStatus
+from metagov.metagov.plugins.opencollective.models import OPEN_COLLECTIVE_GRAPHQL
+from metagov.plugins.opencollective.models import OpenCollective
+from requests.models import PreparedRequest
+from metagov.core.handlers import PluginRequestHandler
+
+
+
+
+logger = logging.getLogger(__name__)
+
+open_collective_settings = settings.METAGOV_SETTINGS["OPEN_COLLECTIVE"]
+OC_CLIENT_ID = open_collective_settings["CLIENT_ID"]
+OC_CLIENT_SECRET = open_collective_settings["CLIENT_SECRET"]
+
+class OpenCollectiveRequestHandler(PluginRequestHandler):
+    def construct_oauth_authorize_url(self, type: str, community=None):
+        if not OC_CLIENT_ID:
+            raise PluginAuthError(detail="Client ID not configured")
+        if not OC_CLIENT_SECRET:
+            raise PluginAuthError(detail="Client secret not configured")
+
+        admin_scopes = ['email', 'account', 'expenses', 'conversations', 'webhooks']
+        # if type == AuthorizationType.APP_INSTALL:    
+        # elif type == AuthorizationType.USER_LOGIN:
+
+        return f"https://opencollective.com/oauth/authorizeauthorize?response_type=code&client_id={OC_CLIENT_ID}&scope={admin_scopes.join(',')}"
+
+    def handle_oauth_callback(
+        self,
+        type: str,
+        code: str,
+        redirect_uri: str,
+        community,
+        request,
+        state=None,
+        external_id=None,
+        *args,
+        **kwargs,
+    ):
+        """
+        OAuth2 callback endpoint handler for authorization code grant type.
+        This function does two things:
+            1) completes the authorization flow,
+            2) enables the OC plugin for the specified community
+
+
+        type : AuthorizationType.APP_INSTALL or AuthorizationType.USER_LOGIN
+        code : authorization code from the server (OC)
+        redirect_uri : redirect uri from the Driver to redirect to on completion
+        community : the Community to enable OC for
+        state : optional state to pass along to the redirect_uri
+        """
+        logger.debug(f"> auth_callback for oc")
+
+        response = _exchange_code(code)
+        logger.info(f"---- {response} ----")
+        user_access_token = response["access_token"]
+
+        logger.info(OPEN_COLLECTIVE_GRAPHQL)
+        # Get user info
+        resp = requests.post(
+            OPEN_COLLECTIVE_GRAPHQL,
+            json={"query": "{ me { id name email } }"},
+            headers={"Authorization": f"Bearer {user_access_token}"}
+        )
+        logger.debug(resp.request.headers)
+        if not resp.ok:
+            logger.error(f"OC req failed: {resp.status_code} {resp.reason}")
+            raise PluginAuthError(detail="Error getting user info for installing user")
+        current_user = resp.json()
+        logger.debug(current_user)
+
+        # TODO: prompt choose collective?
+        collective = 'metagov-test-collective-2'
+
+        if type == AuthorizationType.APP_INSTALL:
+            plugin_config = {"collective_slug": collective, "api_key": user_access_token}
+            plugin = OpenCollective.objects.create(
+                name="opencollective", community=community, config=plugin_config, community_platform_id=collective
+            )
+            logger.debug(f"Created OC plugin: {plugin}")
+
+            params = {
+                # Metagov community that has the OC plugin enabled
+                "community": community.slug,
+                # (Optional) State that was originally passed from Driver, so it can validate it
+                "state": state,
+                # Collective that the user installed PolicyKit to
+                "collective": collective,
+            }
+            url = add_query_parameters(redirect_uri, params)
+            return HttpResponseRedirect(url)
+
+        elif type == AuthorizationType.USER_LOGIN:
+            # Add some params to redirect
+            params = {
+                # # Discord User ID for logged-in user
+                # "user_id": current_user["id"],
+                # # Discord User Token for logged-in user
+                # "user_token": response["access_token"],
+                # # Metagov-integrated guilds that this user belongs to
+                # "guild[]": integrated_guilds,
+                # # (Optional) State that was originally passed from Driver, so it can validate it
+                "state": state,
+            }
+            url = add_query_parameters(redirect_uri, params)
+            return HttpResponseRedirect(url)
+
+        return HttpResponseBadRequest()
+
+
+def _exchange_code(code):
+    data = {
+        "client_id": OC_CLIENT_ID,
+        "client_secret": OC_CLIENT_SECRET,
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": f"{settings.SERVER_URL}/auth/opencollective/callback",
+    }
+    resp = requests.post("https://opencollective.com/oauth/token", data=data)
+    if not resp.ok:
+        logger.error(f"OC auth failed: {resp.status_code} {resp.reason}")
+        raise PluginAuthError
+
+    return resp.json()
+
+
+def add_query_parameters(url, params):
+    req = PreparedRequest()
+    req.prepare_url(url, params)
+    return req.url
+

--- a/metagov/metagov/plugins/opencollective/handlers.py
+++ b/metagov/metagov/plugins/opencollective/handlers.py
@@ -16,7 +16,7 @@ from metagov.core.handlers import PluginRequestHandler
 
 logger = logging.getLogger(__name__)
 
-open_collective_settings = settings.METAGOV_SETTINGS["OPEN_COLLECTIVE"]
+open_collective_settings = settings.METAGOV_SETTINGS["OPENCOLLECTIVE"]
 OC_CLIENT_ID = open_collective_settings["CLIENT_ID"]
 OC_CLIENT_SECRET = open_collective_settings["CLIENT_SECRET"]
 

--- a/metagov/metagov/plugins/opencollective/handlers.py
+++ b/metagov/metagov/plugins/opencollective/handlers.py
@@ -23,12 +23,12 @@ BOT_ACCOUNT_NAME_SUBSTRING = "governance bot"
 
 class NonBotAccountError(PluginAuthError):
     default_code = "non_bot_account"
-    default_details = f"Failed to install. The Open Collective account name must contains string '{BOT_ACCOUNT_NAME_SUBSTRING}' (case insensitive)."
+    default_detail = f"The Open Collective account name must contains string '{BOT_ACCOUNT_NAME_SUBSTRING}' (case insensitive)."
 
 
 class NotOneCollectiveError(PluginAuthError):
     default_code = "not_one_collective"
-    default_details = f"Failed to install. The Open Collective account must be a member of exactly 1 collective."
+    default_detail = f"The Open Collective account must be a member of exactly 1 collective."
 
 class OpenCollectiveRequestHandler(PluginRequestHandler):
     def construct_oauth_authorize_url(self, type: str, community=None):

--- a/metagov/metagov/plugins/opencollective/handlers.py
+++ b/metagov/metagov/plugins/opencollective/handlers.py
@@ -32,7 +32,7 @@ class NotOneCollectiveError(PluginAuthError):
 
 class InsufficientPermissions(PluginAuthError):
     default_code = "insufficient_permissions"
-    default_detail = f"The Open Collective account does not have sufficient permissions. Account must be able to create webhooks for the collective."
+    default_detail = f"The Open Collective account does not have sufficient permissions. Account must be an admin on the collective."
 
 class OpenCollectiveRequestHandler(PluginRequestHandler):
     def construct_oauth_authorize_url(self, type: str, community=None):

--- a/metagov/metagov/plugins/opencollective/handlers.py
+++ b/metagov/metagov/plugins/opencollective/handlers.py
@@ -7,8 +7,7 @@ from django.http.response import HttpResponseBadRequest, HttpResponseRedirect
 from metagov.core.errors import PluginAuthError
 from metagov.core.plugin_manager import AuthorizationType
 from metagov.core.models import ProcessStatus
-from metagov.metagov.plugins.opencollective.models import OPEN_COLLECTIVE_GRAPHQL
-from metagov.plugins.opencollective.models import OpenCollective
+from metagov.plugins.opencollective.models import OpenCollective, OPEN_COLLECTIVE_GRAPHQL
 from requests.models import PreparedRequest
 from metagov.core.handlers import PluginRequestHandler
 

--- a/metagov/metagov/plugins/opencollective/models.py
+++ b/metagov/metagov/plugins/opencollective/models.py
@@ -80,6 +80,7 @@ class OpenCollective(Plugin):
         result = resp.json()
         if result.get("errors"):
             msg = ",".join([e["message"] for e in result["errors"]])
+            logger.error(f"Query failed: {msg}")
             raise PluginErrorInternal(msg)
         return result["data"]
 

--- a/metagov/metagov/plugins/opencollective/models.py
+++ b/metagov/metagov/plugins/opencollective/models.py
@@ -25,7 +25,7 @@ else:
 @Registry.plugin
 class OpenCollective(Plugin):
     name = "opencollective"
-    auth_type = AuthType.API_KEY
+    auth_type = AuthType.OAUTH
     config_schema = {
         "type": "object",
         "additionalProperties": False,

--- a/metagov/metagov/plugins/opencollective/models.py
+++ b/metagov/metagov/plugins/opencollective/models.py
@@ -30,13 +30,13 @@ class OpenCollective(Plugin):
         "type": "object",
         "additionalProperties": False,
         "properties": {
-            "api_key": {"type": "string", "description": "API Key for a user that is an admin on this collective."},
+            "access_token": {"type": "string", "description": "Access token for Open Collective account"},
             "collective_slug": {
                 "type": "string",
                 "description": "Open Collective slug",
             },
         },
-        "required": ["api_key", "collective_slug"],
+        "required": ["access_token", "collective_slug"],
     }
     community_platform_id_key = "collective_slug"
 
@@ -44,14 +44,17 @@ class OpenCollective(Plugin):
         proxy = True
 
     def initialize(self):
+        # Fetch info about collective
         slug = self.config["collective_slug"]
         response = self.run_query(Queries.collective, {"slug": slug})
         result = response["collective"]
         if result is None:
             raise PluginErrorInternal(f"Collective '{slug}' not found.")
 
-        logger.info("Initialized Open Collective: " + str(result))
+        # Create webhook for listening to events on OC
+        self.create_webhook()
 
+        # Store collective information in plugin state
         self.state.set("collective_name", result["name"])
         self.state.set("collective_id", result["id"])
         self.state.set("collective_legacy_id", result["legacyId"])
@@ -62,12 +65,13 @@ class OpenCollective(Plugin):
             ]
 
         self.state.set("project_legacy_ids", project_legacy_ids)
+        logger.info("Initialized Open Collective: " + str(result))
 
     def run_query(self, query, variables):
         resp = requests.post(
             OPEN_COLLECTIVE_GRAPHQL,
             json={"query": query, "variables": variables},
-            headers={"Authorization": f"Bearer {self.config['api_key']}"},
+            headers={"Authorization": f"Bearer {self.config['access_token']}"},
         )
         if not resp.ok:
             logger.error(f"Query failed with {resp.status_code} {resp.reason}: {query}")
@@ -78,6 +82,17 @@ class OpenCollective(Plugin):
             msg = ",".join([e["message"] for e in result["errors"]])
             raise PluginErrorInternal(msg)
         return result["data"]
+
+    def create_webhook(self):
+        webhook_url = f"{settings.SERVER_URL}/api/hooks/{self.name}/{self.community.slug}"
+        logger.debug(f"Creating OC webhook: {webhook_url}")
+        resp = self.run_query(Queries.create_webhook, {
+            "slug": self.config["collective_slug"],
+            "activityType": "ACTIVITY_ALL",
+            "webhookUrl": webhook_url
+        })
+        result = resp.json()
+        logger.debug(result)
 
     @Registry.action(slug="list-members", description="list members of the collective")
     def list_members(self):

--- a/metagov/metagov/plugins/opencollective/models.py
+++ b/metagov/metagov/plugins/opencollective/models.py
@@ -86,7 +86,7 @@ class OpenCollective(Plugin):
     def create_webhook(self):
         webhook_url = f"{settings.SERVER_URL}/api/hooks/{self.name}/{self.community.slug}"
         logger.debug(f"Creating OC webhook: {webhook_url}")
-        resp = self.run_query(Queries.create_webhook, {
+        result = self.run_query(Queries.create_webhook, {
             "webhook": {
                 "account": {
                     "slug": self.config["collective_slug"]
@@ -95,7 +95,6 @@ class OpenCollective(Plugin):
                 "webhookUrl": webhook_url
             }
         })
-        result = resp.json()
         logger.debug(result)
 
     @Registry.action(slug="list-members", description="list members of the collective")

--- a/metagov/metagov/plugins/opencollective/models.py
+++ b/metagov/metagov/plugins/opencollective/models.py
@@ -67,7 +67,7 @@ class OpenCollective(Plugin):
         resp = requests.post(
             OPEN_COLLECTIVE_GRAPHQL,
             json={"query": query, "variables": variables},
-            headers={"Api-Key": f"{self.config['api_key']}"},
+            headers={"Authorization": f"Bearer {self.config['api_key']}"},
         )
         if not resp.ok:
             logger.error(f"Query failed with {resp.status_code} {resp.reason}: {query}")

--- a/metagov/metagov/plugins/opencollective/models.py
+++ b/metagov/metagov/plugins/opencollective/models.py
@@ -87,9 +87,13 @@ class OpenCollective(Plugin):
         webhook_url = f"{settings.SERVER_URL}/api/hooks/{self.name}/{self.community.slug}"
         logger.debug(f"Creating OC webhook: {webhook_url}")
         resp = self.run_query(Queries.create_webhook, {
-            "slug": self.config["collective_slug"],
-            "activityType": "ACTIVITY_ALL",
-            "webhookUrl": webhook_url
+            "webhook": {
+                "account": {
+                    "slug": self.config["collective_slug"]
+                },
+                "activityType": "ACTIVITY_ALL",
+                "webhookUrl": webhook_url
+            }
         })
         result = resp.json()
         logger.debug(result)

--- a/metagov/metagov/plugins/opencollective/queries.py
+++ b/metagov/metagov/plugins/opencollective/queries.py
@@ -156,6 +156,38 @@ query Collective($slug: String) {
 }
 """
 
+me = (
+  """
+  me {
+    id
+    name
+    email
+    memberOf(accountType: COLLECTIVE) {
+      totalCount
+      nodes {
+        account {
+          name
+          slug
+        }
+      }
+    }
+  }
+}
+  """
+)
+
+create_webhook = (
+    """
+mutation CreateWebhook($webhook: WebhookCreateInput!) {
+  createWebhook(webhook: $webhook) {
+    id
+    activityType
+    webhookUrl
+  }
+}
+"""
+)
+
 conversation = (
     """
 query Conversation($id: String!) {

--- a/metagov/metagov/plugins/opencollective/queries.py
+++ b/metagov/metagov/plugins/opencollective/queries.py
@@ -158,6 +158,7 @@ query Collective($slug: String) {
 
 me = (
   """
+{
   me {
     id
     name

--- a/metagov/metagov/plugins/opencollective/queries.py
+++ b/metagov/metagov/plugins/opencollective/queries.py
@@ -184,11 +184,6 @@ mutation CreateWebhook($webhook: WebhookCreateInput!) {
     id
     activityType
     webhookUrl
-    account {
-      id
-      slug
-      name
-    }
   }
 }
 """

--- a/metagov/metagov/plugins/opencollective/queries.py
+++ b/metagov/metagov/plugins/opencollective/queries.py
@@ -184,6 +184,11 @@ mutation CreateWebhook($webhook: WebhookCreateInput!) {
     id
     activityType
     webhookUrl
+    account {
+      id
+      slug
+      name
+    }
   }
 }
 """

--- a/metagov/metagov/plugins/opencollective/tests/test_opencollective.py
+++ b/metagov/metagov/plugins/opencollective/tests/test_opencollective.py
@@ -12,7 +12,7 @@ class ApiTests(PluginTestCase):
                 json={"data": {"collective": {"name": "my community", "id": "xyz", "legacyId": 123}}},
             )
             # enable the plugin
-            self.enable_plugin(name="opencollective", config={"collective_slug": "mycollective", "api_key": "empty"})
+            self.enable_plugin(name="opencollective", config={"collective_slug": "mycollective", "access_token": "empty"})
 
     def test_init_works(self):
         """Plugin is properly initialized"""

--- a/metagov/metagov/settings.py
+++ b/metagov/metagov/settings.py
@@ -111,7 +111,9 @@ METAGOV_SETTINGS = {
         "API_KEY": env("SENDGRID_API_KEY", default=default_val)
     },
     "OPENCOLLECTIVE": {
-        "USE_STAGING": env("OPENCOLLECTIVE_USE_STAGING", default=False)
+        "USE_STAGING": env("OPENCOLLECTIVE_USE_STAGING", default=False),
+        "CLIENT_ID": env("OPENCOLLECTIVE_CLIENT_ID", default=default_val),
+        "CLIENT_SECRET": env("OPENCOLLECTIVE_CLIENT_SECRET", default=default_val),
     }
 }
 


### PR DESCRIPTION
* Use new [Open Collective oauth flow](https://docs.opencollective.com/help/developers/oauth) for OC plugin
* This code attempts to set up webhooks on init using [createWebhook mutation](https://graphql-docs-v2.opencollective.com/mutations/createWebhook) but this part doesn't seem to be working. For now we can continue to expose the webhook URL to the user in the policykit frontend and ask them to add it manually. (https://github.com/policykit/policykit/pull/579)
* And posts made to OC are made as the user who initially installed the oauth flow
* Reject installing user if they don't have "governance bot" in the name