### PR TITLE
New Governance Process `SlackAdvancedVote` to the Slack Plugin

### DIFF
--- a/metagov/metagov/core/models.py
+++ b/metagov/metagov/core/models.py
@@ -141,7 +141,7 @@ def quality_is_greater(a, b):
     return order.index(a) > order.index(b)
 
 
-class Plugin(models.Model):
+class Plugin(models.Model ):
     """Represents an instance of an activated plugin."""
 
     name = models.CharField(max_length=30, blank=True, help_text="Name of the plugin")
@@ -191,10 +191,9 @@ class Plugin(models.Model):
         """Start a new GovernanceProcess"""
         # Find the proxy class for the specified GovernanceProcess
         cls = self.__get_process_cls(process_name)
-        logger.debug("parameters validate: ", kwargs.get("validate"))
+       
         # Convert kwargs to Parameters (does schema validation and filling in default values)
         params = Parameters(values=kwargs, schema=cls.input_schema)
-
         # Create new process instance
         new_process = cls.objects.create(name=process_name, callback_url=callback_url, plugin=self)
         logger.debug(f"Created process: {new_process}")

--- a/metagov/metagov/core/models.py
+++ b/metagov/metagov/core/models.py
@@ -141,7 +141,7 @@ def quality_is_greater(a, b):
     return order.index(a) > order.index(b)
 
 
-class Plugin(models.Model ):
+class Plugin(models.Model):
     """Represents an instance of an activated plugin."""
 
     name = models.CharField(max_length=30, blank=True, help_text="Name of the plugin")
@@ -191,7 +191,6 @@ class Plugin(models.Model ):
         """Start a new GovernanceProcess"""
         # Find the proxy class for the specified GovernanceProcess
         cls = self.__get_process_cls(process_name)
-       
         # Convert kwargs to Parameters (does schema validation and filling in default values)
         params = Parameters(values=kwargs, schema=cls.input_schema)
         # Create new process instance

--- a/metagov/metagov/core/models.py
+++ b/metagov/metagov/core/models.py
@@ -191,7 +191,7 @@ class Plugin(models.Model):
         """Start a new GovernanceProcess"""
         # Find the proxy class for the specified GovernanceProcess
         cls = self.__get_process_cls(process_name)
-
+        logger.debug("parameters validate: ", kwargs.get("validate"))
         # Convert kwargs to Parameters (does schema validation and filling in default values)
         params = Parameters(values=kwargs, schema=cls.input_schema)
 

--- a/metagov/metagov/plugins/slack/handlers.py
+++ b/metagov/metagov/plugins/slack/handlers.py
@@ -11,7 +11,7 @@ from metagov.core.errors import PluginAuthError, PluginErrorInternal
 from metagov.core.handlers import PluginRequestHandler
 from metagov.core.models import LinkQuality, LinkType, ProcessStatus
 from metagov.core.plugin_manager import AuthorizationType
-from metagov.plugins.slack.models import Slack, SlackEmojiVote, SlackAdvancedVote
+from metagov.plugins.slack.models import Slack, SlackEmojiVote, SlackAdvancedVote, ADVANCED_VOTE_ACTION_ID, VOTE_ACTION_ID, CONFIRM_ADVANCED_VOTE
 from requests.models import PreparedRequest
 
 logger = logging.getLogger(__name__)
@@ -61,18 +61,20 @@ class SlackRequestHandler(PluginRequestHandler):
             if payload["type"] != "block_actions":
                 return
             team_id = payload["team"]["id"]
-            if len(payload["actions"]) > 0 and payload["actions"][0]["type"] == "button":
-                for plugin in Slack.objects.filter(community_platform_id=team_id):
-                    active_emoji_vote_processes = SlackEmojiVote.objects.filter(plugin=plugin, status=ProcessStatus.PENDING.value)
-                    for process in active_emoji_vote_processes:
-                        logger.info(f"Passing Slack interaction to {process}")
-                        process.receive_webhook(request)
-            elif len(payload["actions"]) > 0 and payload["actions"][0]["type"] == "static_select":
-                for plugin in Slack.objects.filter(community_platform_id=team_id):
-                    active_advanced_vote_processes = SlackAdvancedVote.objects.filter(plugin=plugin, status=ProcessStatus.PENDING.value)
-                    for process in active_advanced_vote_processes:
-                        logger.info(f"Passing Slack interaction to {process}")
-                        process.receive_webhook(request)
+            if len(payload["actions"]) > 0:
+                action_id_example = payload["actions"][0]["action_id"]
+                if action_id_example == VOTE_ACTION_ID:
+                    for plugin in Slack.objects.filter(community_platform_id=team_id):
+                        active_emoji_vote_processes = SlackEmojiVote.objects.filter(plugin=plugin, status=ProcessStatus.PENDING.value)
+                        for process in active_emoji_vote_processes:
+                            logger.info(f"Passing Slack interaction to {process}")
+                            process.receive_webhook(request)
+                elif action_id_example.startswith(ADVANCED_VOTE_ACTION_ID) or action_id_example == CONFIRM_ADVANCED_VOTE:
+                    for plugin in Slack.objects.filter(community_platform_id=team_id):
+                        active_advanced_vote_processes = SlackAdvancedVote.objects.filter(plugin=plugin, status=ProcessStatus.PENDING.value)
+                        for process in active_advanced_vote_processes:
+                            logger.info(f"Passing Slack interaction to {process}")
+                            process.receive_webhook(request)
             return
 
         # Assume that this is a request from the Slack Events API

--- a/metagov/metagov/plugins/slack/handlers.py
+++ b/metagov/metagov/plugins/slack/handlers.py
@@ -11,7 +11,7 @@ from metagov.core.errors import PluginAuthError, PluginErrorInternal
 from metagov.core.handlers import PluginRequestHandler
 from metagov.core.models import LinkQuality, LinkType, ProcessStatus
 from metagov.core.plugin_manager import AuthorizationType
-from metagov.plugins.slack.models import Slack, SlackEmojiVote, SlackAdvancedVote, ADVANCED_VOTE_ACTION_ID, VOTE_ACTION_ID, CONFIRM_ADVANCED_VOTE
+from metagov.plugins.slack.models import Slack, SlackEmojiVote, SlackAdvancedVote, ADVANCED_VOTE_ACTION_ID, VOTE_ACTION_ID
 from requests.models import PreparedRequest
 
 logger = logging.getLogger(__name__)
@@ -69,7 +69,7 @@ class SlackRequestHandler(PluginRequestHandler):
                         for process in active_emoji_vote_processes:
                             logger.info(f"Passing Slack interaction to {process}")
                             process.receive_webhook(request)
-                elif action_id_example.startswith(ADVANCED_VOTE_ACTION_ID) or action_id_example == CONFIRM_ADVANCED_VOTE:
+                elif action_id_example.startswith(ADVANCED_VOTE_ACTION_ID):
                     for plugin in Slack.objects.filter(community_platform_id=team_id):
                         active_advanced_vote_processes = SlackAdvancedVote.objects.filter(plugin=plugin, status=ProcessStatus.PENDING.value)
                         for process in active_advanced_vote_processes:


### PR DESCRIPTION
The implementation is similar to SlackEmojiVote. 

This new governance process accepts a list of candidates and options and then initiates a vote in Slack where users can select an option for each candidate. The outcome of the vote will be stored as a dict {user: {candidate1: option1, ...}, }

To allow the new governance to receive webhook events, in the `handlers.py` of Slack, we also check whether the actions of the payload are is`VOTE_ACTION_ID` or start with `ADVANCED_VOTE_ACTION_ID)`, and pass events to the corresponding governance process.